### PR TITLE
Update to SabreDAV 3.0.0

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -1,7 +1,7 @@
 {
 	"name" : "1afa/sambadav",
 	"require" : {
-		"sabre/dav" : "~2.1.0"
+		"sabre/dav" : "~3.0.0"
 	},
 	"license" : "agpl",
 	"authors" : [

--- a/src/server.php
+++ b/src/server.php
@@ -119,7 +119,7 @@ $server->addPlugin($plugin);
 
 // Compatibility fix for Microsoft Word 2003,
 // Otherwise harmless, according to http://sabre.io/dav/clients/msoffice:
-\Sabre\DAV\Property\LockDiscovery::$hideLockRoot = true;
+\Sabre\DAV\Xml\Property\LockDiscovery::$hideLockRoot = true;
 
 // Custom plugin to add the nonstandard DAV:ishidden and DAV:isreadonly flags:
 $server->addPlugin(new MSPropertiesPlugin());


### PR DESCRIPTION
Using the provided SabreDAV 2.1 I got a lot of PHP errors (`fread() expects parameter 1 to be resource, boolean given`) when trying to upload/edit files in `vendor/sabre/dav/lib/DAV/FSExt/Node.php:148`. It's working perfect with SabreDAV 3.0.0.