### PR TITLE
Added simple delete function in Browser Plugin

### DIFF
--- a/src/config/config.inc.php
+++ b/src/config/config.inc.php
@@ -118,4 +118,6 @@ return array(
 	// in order of verboseness from least to most:
 	'log_level' => 'warn',
 
+	// Set to true to enable delete buttons in web interface
+	'browserplugin_enable_delete' => false,
 );


### PR DESCRIPTION
Simple delete function for Browser Plugin. Disabled by default and controller by `browserplugin_enable_delete` in `config/config.inc.php`. 

This time with an additional POST hook.

https://github.com/1afa/sambadav/issues/11#issuecomment-137752438