### PR TITLE
Fix psr-4 autoloading

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -18,7 +18,7 @@
 	],
 	"autoload" : {
 		"psr-4" : {
-			"SambaDAV\\" : "lib/"
+			"SambaDAV\\" : "lib/SambaDAV"
 		}
 	},
 	"minimum-stability" : "stable"


### PR DESCRIPTION
With the previous psr-4 spec the phpunit tests failed with a fatal error:

  Class 'SambaDAV\Log' not found in path/sambadav-0.6.0/tests/SambaDAV/LogTest.php on line 45

See https://travis-ci.org/1afa/sambadav/builds for build results