### PR TITLE
Fixed - SambaDav Directory constructor not calling the parent constru…

### DIFF
--- a/src/lib/SambaDAV/Directory.php
+++ b/src/lib/SambaDAV/Directory.php
@@ -38,6 +38,7 @@ class Directory extends DAV\FSExt\Directory
 		$this->cache = $cache;
 		$this->log = $log;
 		$this->smb = $smb;
+		parent::__construct($uri->path());
 	}
 
 	public function


### PR DESCRIPTION
…ctor - path property not set

When extending object, it is good practice to call the parent::__construct function so the object is properly initialised. In this case, the Directory path property will be set properly instead of remaining NULL otherwise which may root cause of issue further down the line otherwise (e.g rename function triggered where the source path would be empty).